### PR TITLE
fix userId bug - now userId appears on first tweet after signUp

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,7 +92,8 @@ module.exports = function(knex) {
     knex('users').insert({ email: req.body.email, hashed_password: hash })
     .then(function(data){
       console.log('this is "data" from sign-up', data)
-      req.session.userId = data
+      console.log("this is data[0]: ", data[0])
+      req.session.userId = data[0]
       res.redirect('/secret')
     })
     .catch(function(error){
@@ -110,6 +111,7 @@ module.exports = function(knex) {
         console.log('this is "data" from sign in: ', data)
         if (bcrypt.compareSync( req.body.password, data[0].hashed_password )) {
           req.session.userId = data[0].id
+          // console.log("this is data[0].id: ", data[0].id)
           res.redirect('/secret')
           console.log('success! sign in happened by cretin #' + req.session.userId +'!')
         }


### PR DESCRIPTION
Hey @jess-of-the-woods and Heidi we have fixed a wee bug; Originally the userId was not displaying on the viewAllTweets page, next to the tweet, when a newly signed up user posted their first tweet, only when they signed out and signed in again did it show up. It now appears on the first signUp.
Screenshot shows cretin #14's tweets with their user id appearing next to their tweet immediately after first sign up.

![screen shot 2016-04-27 at 12 31 50 pm 2](https://cloud.githubusercontent.com/assets/16638694/14838323/60c29476-0c74-11e6-8851-1edbfa2f14f9.png)
